### PR TITLE
Allow 0 to be a valid value

### DIFF
--- a/Slider.php
+++ b/Slider.php
@@ -52,7 +52,7 @@ class Slider extends \kartik\base\InputWidget
     {
         parent::init();
 
-        if (!empty($this->value)) {
+        if (!empty($this->value) || $this->value === 0) {
             if (is_array($this->value)) {
                 throw new InvalidConfigException("Value cannot be passed as an array. If you wish to setup a range slider, pass the two values together as strings separated with a ',' sign.");
             }


### PR DESCRIPTION
If I set `value` to 0, it would get rendered as null:

```
 echo Slider::widget([
            'name' => 'somevalue',
            'value'=> 0,
            'pluginOptions' => [
                'min' => 0,
                'max' => 15,
                'step' => .25
            ],
        ]);
```

```
var slider_bf093871 = {"min":0,"max":15,"step":0.25,"value":null,"id":"w0-slider"};
```

And the slider would get positioned at some random value.

With my patch, it renders correctly:

```
var slider_449938cc = {"min":0,"max":15,"step":0.25,"value":0,"id":"w0-slider"};
```
