### PR TITLE
Support of input value being a number but typed as a string

### DIFF
--- a/Slider.php
+++ b/Slider.php
@@ -57,7 +57,7 @@ class Slider extends \kartik\base\InputWidget
     {
         parent::init();
 
-        if (!empty($this->value) || $this->value === 0) {
+        if (!empty($this->value) || $this->value == 0) {
             if (is_array($this->value)) {
                 throw new InvalidConfigException("Value cannot be passed as an array. If you wish to setup a range slider, pass the two values together as strings separated with a ',' sign.");
             }


### PR DESCRIPTION
I faced issues as the input field was considered as a string and not a number.
Proposed solution is more robust in case value is '0'. (not as clean and strict but should not be an issue)