### PR TITLE
Handling when input is a numeric string

### DIFF
--- a/Slider.php
+++ b/Slider.php
@@ -57,7 +57,7 @@ class Slider extends \kartik\base\InputWidget
     {
         parent::init();
 
-        if (!empty($this->value) || $this->value === 0) {
+        if (!empty($this->value) || $this->value == 0) {
             if (is_array($this->value)) {
                 throw new InvalidConfigException("Value cannot be passed as an array. If you wish to setup a range slider, pass the two values together as strings separated with a ',' sign.");
             }

--- a/Slider.php
+++ b/Slider.php
@@ -57,7 +57,7 @@ class Slider extends \kartik\base\InputWidget
     {
         parent::init();
 
-        if (!empty($this->value) || $this->value == 0) {
+        if (!empty($this->value) || $this->value === 0 || $this->value === "0") {
             if (is_array($this->value)) {
                 throw new InvalidConfigException("Value cannot be passed as an array. If you wish to setup a range slider, pass the two values together as strings separated with a ',' sign.");
             }


### PR DESCRIPTION
If the input is a numeric string (eg. "1" or "7") it works except for value "0". 
The patch fixes this.