### PR TITLE
defult value changed form 5 to 0

### DIFF
--- a/assets/js/bootstrap-slider.js
+++ b/assets/js/bootstrap-slider.js
@@ -703,7 +703,7 @@ function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.const
 				step: 1,
 				precision: 0,
 				orientation: 'horizontal',
-				value: 5,
+				value: 0,
 				range: false,
 				selection: 'before',
 				tooltip: 'show',


### PR DESCRIPTION
default value must be set to zero, because in the value assigning section you are checking is the value mentioned by user is null

> val = val !== null ? val : this.defaultOptions[optName];

so if we try to set value as zero then your code will consider it as not mentioned any value so take default where default is 5,

please release new version as soon as possible 